### PR TITLE
Fix: Correct Sites of Interest page content and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
             <div id="mySidebar" class="sidebar">
                 <a href="javascript:void(0)" class="closebtn" onclick="closeNav()">×</a>
                 <a href="about.html">About</a>
-                <a href="about.html">Sites of Interest</a>
+                <a href="sites-of-interest.html">Sites of Interest</a>
                 <a href="projects.html">Projects</a>
                 <a href="#">Contacts</a>
                 <a href="upload.html">UPLOAD CONTENT</a>

--- a/sites-of-interest.html
+++ b/sites-of-interest.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sites of Interest</title>
+    <link rel="stylesheet" type="text/css" href="styles.css">
+</head>
+<body>
+    <h1>Sites of Interest</h1>
+    <p>Here are some links you might find interesting:</p>
+    <ul>
+        <li><a href="http://www.google.com" target="_blank">Google</a></li>
+        <li><a href="http://www.github.com" target="_blank">GitHub</a></li>
+    </ul>
+
+    <a href="index.html">
+        <button>Return to Homepage</button>
+    </a>
+
+    <div class="footer">
+        <p>You are in the right place.</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
The "Sites of Interest" page was previously displaying the content of the "About" page.

This commit introduces the following changes:
- Creates a new `sites-of-interest.html` file.
- Adds two links (Google and GitHub) to `sites-of-interest.html` as you requested.
- Updates the navigation link in `index.html` to correctly point to `sites-of-interest.html`.
- Ensures the styling and structure of the new page are consistent with other pages like `about.html`.

The "Sites of Interest" page now displays the correct content, and the navigation directs you to this new page.