### PR TITLE
Add new links to Sites of Interest page

### DIFF
--- a/sites-of-interest.html
+++ b/sites-of-interest.html
@@ -12,6 +12,9 @@
     <ul>
         <li><a href="http://www.google.com" target="_blank">Google</a></li>
         <li><a href="http://www.github.com" target="_blank">GitHub</a></li>
+        <li><a href="http://reactbits.dev" target="_blank">reactbits.dev</a></li>
+        <li><a href="http://animejs.com" target="_blank">animejs.com</a></li>
+        <li><a href="http://www.gsap.com" target="_blank">www.gsap.com</a></li>
     </ul>
 
     <a href="index.html">


### PR DESCRIPTION
I added the following links to the `sites-of-interest.html` page:
- reactbits.dev
- animejs.com
- www.gsap.com

These links open in a new tab, consistent with the existing links on the page.